### PR TITLE
hotfix/(514.121)FALHA-DE-SEGURANCA-GRAVE-API-APP-PARANA

### DIFF
--- a/src/Horse.BasicAuthentication.pas
+++ b/src/Horse.BasicAuthentication.pas
@@ -153,7 +153,7 @@ begin
     except
 	  on E: EEncodingError do
       begin
-        Res.Send('Erro na conversão do Base64. Certifique-se de que a string Base64 está correta.').Status(THTTPStatus.InternalServerError);
+        Res.Send('Base64 conversion error. Make sure that the Base64 string is correct.').Status(THTTPStatus.InternalServerError);
         raise EHorseCallbackInterrupted.Create;
       end;
       on E: exception do


### PR DESCRIPTION
* :bug: fix: add correção para decode base64 non base64 string

Movido bloco que realiza o decode de base64 para string para dentro do bloco try except e adicionando tratativa de conversão para mensagem de retorno.